### PR TITLE
[Fix] 상품조회 및 이미지 조회 기능 수정

### DIFF
--- a/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/image/repository/ImageRepository.java
+++ b/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/image/repository/ImageRepository.java
@@ -15,4 +15,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     @Query("select i from Image i where i.fileType =:fileType and i.targetId =:targetId and i.isDeleted = false ")
     Optional<Image> findImagesBySearchCond(@Param("targetId") Long targetId, @Param("fileType") FileType fileType);
+
+    List<Image> findAllByTargetId(Long targetId);
+
+
 }

--- a/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/image/service/ImageRdbService.java
+++ b/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/image/service/ImageRdbService.java
@@ -47,6 +47,14 @@ public class ImageRdbService {
     }
 
 
+    public List<ImageDomain> getAllImageByTargetId(final Long targetId) {
+        return imageRepository.findAllByTargetId(targetId)
+                .stream()
+                .map(ImageEntityMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+
     @Transactional
     public void deleteImages(Long targetId, List<FileType> fileTypes) {
         // ImageRepository에서 FileType 및 targetId이 일치하는 이미지 조회

--- a/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/product/repository/ProductQueryRepository.java
+++ b/shoppingmall/domain/domain-rdb/src/main/java/shoppingmall/domainrdb/product/repository/ProductQueryRepository.java
@@ -53,8 +53,8 @@ public class ProductQueryRepository {
     }
 
     private BooleanExpression categoryIdEq(Long categoryId) {
-        return StringUtils.hasText(String.valueOf(categoryId)) ? product.category.id
-                .eq(categoryId) : null;
+        return categoryId != null ? product.category.id.eq(categoryId) : null;
+
     }
 
     private BooleanExpression productNameEq(String productName) {

--- a/shoppingmall/domain/domain-service/src/main/java/shoppingmall/domainservice/domain/image/service/ImageSearchService.java
+++ b/shoppingmall/domain/domain-service/src/main/java/shoppingmall/domainservice/domain/image/service/ImageSearchService.java
@@ -17,9 +17,12 @@ public class ImageSearchService {
 
     public List<ImageDomain> searchImage(final Long targetId, final List<FileType> fileTypes) {
 
-        return fileTypes.stream().map(
-                fileType -> imageRdbService.getImage(targetId, fileType)
-        ).collect(Collectors.toUnmodifiableList());
+
+
+        if ( fileTypes == null || fileTypes.isEmpty()) {
+            return imageRdbService.getAllImageByTargetId(targetId);
+        }
+        return fileTypes.stream().map(fileType -> imageRdbService.getImage(targetId, fileType)).collect(Collectors.toList());
 
     }
 }


### PR DESCRIPTION
# 완료한 것
- 상품조회 시 null값인 경우 예외 발생에 따라 Querydsl 로직 수정
- Image조회시 Filetype null일경우 모든 targetId에 해당하는 모든 이미지 조회 가능하게끔 수정
# 고민한 것

# To-Do
- 슬로우 쿼리 설정 및 부하테스트 진행